### PR TITLE
fix for review

### DIFF
--- a/src/components/PopupWithConfirmation.js
+++ b/src/components/PopupWithConfirmation.js
@@ -12,10 +12,10 @@ class PopupWithConfirmation extends Popup {
     this._formElement.addEventListener("submit", (evt) => {
       evt.preventDefault();
       this._submitForm(evt, this._cardId)
-      .then(this._callback)
-      .catch((err) => {
-        console.log(err);
-      });
+      .then(() => {
+        this._callback();
+        this.close();
+      })
     });
   }
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -81,8 +81,10 @@ const handleCardAddFormSubmit = (evt, inputValues) => {
 };
 
 const handleCardRemoveFormSubmit = (evt, cardId) => {
-  removeCardIntance.close();
-  return api.removeCard(cardId);
+  return api.removeCard(cardId)
+    .catch((err)=>{
+      console.log(err)
+    });
 };
 
 const handleAvatarFormSubmit = (evt, inputValues) => {


### PR DESCRIPTION
Исправления следующих ошибок:
1. PopupWithConfirmation не может знать, как обрабатывать ошибки сервера, поэтому catch должен быть в index.js
2. Закрывать попапы нужно только после удачного ответа от сервера в блоке then, иначе пользователь не поймет, что произошла ошибка, к тому же инпуты могут очиститься, и придется опять печатать данные для отправки (а формы иногда бывают по 10-15 инпутов). А еще не будет видно изменение текста кнопки сабмита, если его делаете.